### PR TITLE
Changes:

### DIFF
--- a/rabix/cliche/adapter.py
+++ b/rabix/cliche/adapter.py
@@ -9,7 +9,7 @@ import execjs
 from six.moves import reduce
 from jsonschema import Draft4Validator
 
-from rabix.cliche.ref_resolver import from_url
+from rabix.cliche.ref_resolver import from_url, resolve_pointer
 from rabix.cliche.expressions.evaluator import Evaluator
 
 
@@ -37,7 +37,7 @@ def sort_args(args):
 
 
 class Argument(object):
-    def __init__(self, job, value, schema, adapter=None):
+    def __init__(self, job, value, schema, adapter=None, basedir=""):
         self.job = job
         self.schema = schema or {}
         if 'oneOf' in self.schema:
@@ -53,7 +53,7 @@ class Argument(object):
         if self.transform:
             value = evaluate(self.transform, self.job, value)
         elif self.schema.get('type') in ('file', 'directory'):
-            value = value['path']
+            value = value['path'] if os.path.isabs(value['path']) else os.path.join(basedir, value['path'])
         self.value = value
 
     def __int__(self):
@@ -67,26 +67,22 @@ class Argument(object):
         if key in self.schema.get('properties', {}):
             return self.schema['properties'][key]
 
-    def get_args_and_stdin(self, adapter_mixins=None):
-        args = [Argument(self.job, v, self._schema_for(k)) for k, v in
+    def get_args(self, adapter_mixins=None, basedir=""):
+        args = [Argument(self.job, v, self._schema_for(k), basedir=basedir) for k, v in
                 sorted(six.iteritems(self.value))]
         args += adapter_mixins or []
         args = sort_args(args)
-        stdin = [a.value for a in args if a.is_stdin()]
-        return reduce(operator.add, [a.arg_list() for a in args], []),\
-            stdin[0] if stdin else None
+        return reduce(operator.add, [a.arg_list(basedir) for a in args], [])
 
-    def arg_list(self):
-        if self.is_stdin() or self.adapter is None:
-            return []
+    def arg_list(self, basedir):
         if isinstance(self.value, dict):
-            return self._as_dict()
+            return self._as_dict(basedir)
         if isinstance(self.value, list):
-            return self._as_list()
-        return self._as_primitive()
-
-    def is_stdin(self):
-        return self.adapter.get('stdin')
+            return self._as_list(basedir)
+        if self.adapter:
+            return self._as_primitive()
+        else:
+            return []
 
     def _as_primitive(self):
         if self.value in (None, False):
@@ -101,32 +97,32 @@ class Argument(object):
                 else [self.prefix, self.value]
         return [self.prefix + self.separator + six.text_type(self.value)]
 
-    def _as_dict(self):
-        args = [Argument(self.job, v, self._schema_for(k)) for k, v
+    def _as_dict(self, basedir):
+        args = [Argument(self.job, v, self._schema_for(k), basedir=basedir) for k, v
                 in sorted(six.iteritems(self.value))]
         args = sort_args(args)
-        return reduce(operator.add, [a.arg_list() for a in args], [])
+        return reduce(operator.add, [a.arg_list(basedir) for a in args], [])
 
-    def _as_list(self):
+    def _as_list(self, basedir):
         item_schema = self.schema.get('items', {})
-        args = [Argument(self.job, item, item_schema) for item in self.value]
+        args = [Argument(self.job, item, item_schema, basedir=basedir) for item in self.value]
         if not self.prefix:
-            return reduce(operator.add, [a.arg_list() for a in args], [])
+            return reduce(operator.add, [a.arg_list(basedir) for a in args], [])
         if self.separator is None and self.item_separator is None:
             return reduce(operator.add, [[self.prefix] + a.arg_list()
                                          for a in args], [])
         if self.separator is not None and self.item_separator is None:
             return [self.prefix + self.separator + a._list_item() for a
                     in args if a._list_item() is not None]
-        args_as_strings = [a._list_item() for a in args
-                           if a._list_item() is not None]
+        args_as_strings = [a._list_item(basedir) for a in args
+                           if a._list_item(basedir) is not None]
         joined = self.item_separator.join(args_as_strings)
         if self.separator is None and self.item_separator is not None:
             return [self.prefix, joined]
         return [self.prefix + self.separator + joined]
 
-    def _list_item(self):
-        as_arg_list = self.arg_list()
+    def _list_item(self, basedir):
+        as_arg_list = self.arg_list(basedir)
         if not as_arg_list:
             return None
         if len(as_arg_list) > 1:
@@ -154,15 +150,20 @@ class Adapter(object):
         if isinstance(self.base_cmd, six.string_types):
             self.base_cmd = self.base_cmd.split(' ')
         self.stdout = self.adapter.get('stdout')
+        self.stdin = self.adapter.get('stdin')
         self.args = self.adapter.get('args', [])
         self.input_schema = self.tool.get('inputs', {})
         self.output_schema = self.tool.get('outputs', {})
 
-    def _arg_list_and_stdin(self, job):
-        adapter_args = [Argument(job, self._get_value(a, job), {}, a)
+    def _arg_list_and_stdin(self, job, basedir):
+        adapter_args = [Argument(job, self._get_value(a, job), {}, a, basedir=basedir)
                         for a in self.args]
-        return Argument(job, job['inputs'], self.input_schema).\
-            get_args_and_stdin(adapter_args)
+
+        stdin = self._get_value({"value": self.stdin}, job) if self.stdin else None
+        stdin = stdin if stdin is None or os.path.isabs(stdin) else os.path.join(basedir, stdin)
+
+        return Argument(job, job['inputs'], self.input_schema, basedir=basedir).\
+            get_args(adapter_args, basedir=basedir), stdin
 
     def _resolve_job_resources(self, job):
         resolved = copy.deepcopy(job)
@@ -189,6 +190,8 @@ class Adapter(object):
         return ' '.join(self.get_shell_args(job))
 
     def _get_stdout_name(self, job):
+        if self.stdout is None:
+            return None
         if isinstance(self.stdout, six.string_types):
             return self.stdout
         if '$expr' in self.stdout:
@@ -202,6 +205,8 @@ class Adapter(object):
             raise Exception('Value not specified for arg %s' % arg)
         if isinstance(value, dict) and '$expr' in value:
             value = evaluate(value, job, None)
+        elif isinstance(value, dict) and '$job' in value:
+            value = resolve_pointer(job, value["$job"])
         return value
 
     @staticmethod

--- a/rabix/cliche/main.py
+++ b/rabix/cliche/main.py
@@ -13,13 +13,15 @@ def main():
     parser.add_argument("tool", type=str)
     parser.add_argument("job_order", type=str)
     parser.add_argument("--conformance-test", action="store_true")
+    parser.add_argument("--basedir", type=str)
+    parser.add_argument("--no-container", action="store_true")
     args = parser.parse_args()
 
     tool = from_url(args.tool)
     job = from_url(args.job_order)
     adapter = Adapter(tool)
     base_args = adapter._base_args(job)
-    args, stdin = adapter._arg_list_and_stdin(job)
+    args, stdin = adapter._arg_list_and_stdin(job, basedir=args.basedir)
     stdout = adapter._get_stdout_name(job)
     print(json.dumps({
         'args': map(six.text_type, base_args + args),


### PR DESCRIPTION
- Move 'stdin' from being a property of the adapter of a specific input to being part of the global tool adapter, for consistency with 'stdout'
- Add '--basedir' parameter and resolve relative paths in the input using 'basedir'.
- Add support for "$job" pointers into the job order, usable anywhere "$expr" is supported.
- 5 out of 6 conformance tests pass.

If 'order' is the same then cwltool puts tool adapter args before the 'inputs' adapters, but rabix is the other way around (I don't know if that is intentional or just an accident of implementation).  Also, somehow I broke "-I1,2,3,4" parameter, but I'm hoping someone more familiar with the code can fix these two issues.
