### PR TITLE
check for dockerImageId

### DIFF
--- a/rabix/docker/docker_app.py
+++ b/rabix/docker/docker_app.py
@@ -244,4 +244,4 @@ class DockerContainer(Container):
 
     @classmethod
     def from_dict(cls, context, d):
-        return cls(d.get('dockerPull'))
+        return cls(d.get('dockerPull', d.get('dockerImageId')))


### PR DESCRIPTION
Allow tools that provide docker image id, but no pull information (ie tool docker image exists on local server, but not at registry)