### PR TITLE
Join list with separator when no prefix is present

### DIFF
--- a/rabix/cli/adapter.py
+++ b/rabix/cli/adapter.py
@@ -143,7 +143,7 @@ class InputAdapter(object):
         items = [InputAdapter(item, self.evaluator, schema)
                  for item in self.value]
 
-        if not self.prefix:
+        if not self.prefix and self.item_separator is None:
             return reduce(operator.add, [a.arg_list() for a in items], [])
 
         if self.separate and self.item_separator is None:
@@ -159,6 +159,8 @@ class InputAdapter(object):
         )
 
         if self.separate and self.item_separator is not None:
+            if not self.prefix:
+                return [joined]
             return [self.prefix, joined]
         return [self.prefix + joined]
 


### PR DESCRIPTION
I have a tool that expects input files as comma-separated list, but with no prefix to that argument in command line:

`express args listItem1,listItem2`

With this fix, rabix evaluates cmd well, however I haven't run it through tests.
